### PR TITLE
Fix compile error ..

### DIFF
--- a/setup_translate.py
+++ b/setup_translate.py
@@ -32,11 +32,11 @@ class build_trans(cmd.Command):
 					for lang_domain in lang_domains:
 						lang_domain = lang_domain.rsplit('/', 1)[1]
 						dest = os.path.join(destdir, lang_domain[:-3] + 'mo')
-						print "Language compile %s -> %s" % (src, dest)
+						print("Language compile %s -> %s" % (src, dest))
 						if os.system("msgfmt '%s' -o '%s'" % (src, dest)) != 0:
 							raise Exception, "Failed to compile: " + src
 		else:
-			print "we got no domain -> no translation was compiled"
+			print("we got no domain -> no translation was compiled")
 
 
 class build(_build):


### PR DESCRIPTION
extnumberzap/1+gitAUTOINC+146c370bfa-r0/git/setup_translate.py", line 35
|     print "Language compile %s -> %s" % (src, dest)
|     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
| SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?
| ERROR: 'python3 setup.py build ' execution failed.