### PR TITLE
setup_translate.py: Fix raise() syntax

### DIFF
--- a/setup_translate.py
+++ b/setup_translate.py
@@ -34,7 +34,7 @@ class build_trans(cmd.Command):
 						dest = os.path.join(destdir, lang_domain[:-3] + 'mo')
 						print("Language compile %s -> %s" % (src, dest))
 						if os.system("msgfmt '%s' -o '%s'" % (src, dest)) != 0:
-							raise Exception, "Failed to compile: " + src
+							raise Exception("Failed to compile: " + src)
 		else:
 			print("we got no domain -> no translation was compiled")
 


### PR DESCRIPTION
    raise Exception, "Failed to compile: " + src
|                    ^
| SyntaxError: invalid syntax