### PR TITLE
plugin.py: Remove exec python 2 syntax

### DIFF
--- a/src/plugin.py
+++ b/src/plugin.py
@@ -55,19 +55,13 @@ def actionConfirmed(self, action, retval):
 		entry = ACTIONLIST[action]
 		if entry['type'] == 'code':
 			if entry['args']:
-				if six.PY2:
-					exec entry['args'] in globals(), locals()
-				else:
-					exec(entry['args'] in globals(), locals())
+				exec(entry['args'] in globals(), locals())
 		elif entry['type'] == 'screen':
 			screen = entry.get('screen')
 			if screen:
 				module = entry.get('module')
 				if module:
-					if six.PY2:
-						exec 'from ' + module + ' import ' + screen in globals(), locals()
-					else:
-						exec('from ' + module + ' import ' + screen in globals(), locals())
+					exec('from ' + module + ' import ' + screen in globals(), locals())
 				self.session.open(*eval(screen + ', ' + entry['args']))
 		elif entry['type'] == 'setup':
 			from Screens.Setup import Setup
@@ -107,10 +101,7 @@ def actionConfirmed(self, action, retval):
 					if execstr or openstr:
 						break
 				if execstr:
-					if six.PY2:
-						exec execstr in globals(), locals()
-					else:
-						exec(execstr in globals(), locals())
+					exec(execstr in globals(), locals())
 				if openstr:
 					self.session.open(*eval(openstr))
 


### PR DESCRIPTION
exec() as function is compatible with python 2 and 3.
https://portingguide.readthedocs.io/en/latest/builtins.html#the-exec-function